### PR TITLE
Update gitversion to increment patch by default

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,3 @@
 branches:
   master:
-    increment: Minor
+    increment: Patch


### PR DESCRIPTION
The most common updates are usually updates of dependencies, which do not qualify for a `Minor` inrement.
`Minor` has to be incremented manually if a new feature is added.