### PR TITLE
Fill release with last commit message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: build
     runs-on: ubuntu-latest
+    env:
+      RELEASE_MSG: ${{ github.event.head_commit.message }}
 
     steps:
     - name: Checkout
@@ -63,6 +65,7 @@ jobs:
       with:
         tag_name: ${{ steps.gitversion.outputs.majorMinorPatch }}
         release_name: Release ${{ steps.gitversion.outputs.majorMinorPatch }}
+        body: ${{ env.RELEASE_MSG }}
 
     - name: Upload binary to release
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
It is likely that the release message looks strange, because the commit
message will probably contain header and body. I need to test the
formatting on the next release to see how it's best to fromat it.

Fixes #24