### PR TITLE
Fix potentially failing builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
       run: nuget restore Spectator-Disabler.sln
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.4
+      uses: gittools/actions/gitversion/setup@v0.9.7
       with:
         versionSpec: '5.3.x'
 
     - name: Use GitVersion
-      uses: gittools/actions/gitversion/execute@v0.9.4
+      uses: gittools/actions/gitversion/execute@v0.9.7
       with:
         updateAssemblyInfo: true
         updateAssemblyInfoFilename: Spectator-Disabler/Properties/AssemblyInfo.cs
@@ -54,13 +54,13 @@ jobs:
         fetch-depth: 0
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.4
+      uses: gittools/actions/gitversion/setup@v0.9.7
       with:
           versionSpec: '5.3.x'
 
     - name: Use GitVersion
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.4
+      uses: gittools/actions/gitversion/execute@v0.9.7
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.7
       with:
-        versionSpec: '5.3.x'
+        versionSpec: '5.x'
 
     - name: Use GitVersion
       uses: gittools/actions/gitversion/execute@v0.9.7
@@ -56,7 +56,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.7
       with:
-          versionSpec: '5.3.x'
+          versionSpec: '5.x'
 
     - name: Use GitVersion
       id: gitversion


### PR DESCRIPTION
GitHub removed support for env-vars in actions. This upgrades a used action, that relied on env-vars.