### PR TITLE
Improve creation of release message

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,11 @@ jobs:
       with:
         name: binary
 
+    - name: Format release message
+      id: release_message
+      run: |
+        echo ::set-output name=message::"$(echo '${{ github.event.head_commit.message }}' | tail -n +2)"
+
     - name: Create a Release
       id: create_release
       uses: actions/create-release@v1
@@ -75,7 +80,7 @@ jobs:
       with:
         tag_name: ${{ steps.gitversion.outputs.majorMinorPatch }}
         release_name: Release ${{ steps.gitversion.outputs.majorMinorPatch }}
-        body: ${{ github.event.head_commit.message }}
+        body: ${{ steps.release_message.outputs.message }}
 
     - name: Upload binary to release
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
### Summary
<!-- Provide a general description of your changes. -->
Simplifies writing of release message by not requiring the commit header to be the heading for the release message.

Instead of a commit message like this:
```
## Heading for release message

Description of release with possible:
- bullet points
- tables
- etc
```

The commit heading can be left intact and the full release message can be written inside the commit body:
```
Merge pull request #123 from abc/def

## Heading for release message
Description of release with possible:
- bullet points
- tables
- etc
```
